### PR TITLE
Fixed README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Docker image for Elastic Topbeat
 
 ### Console
 
-      docker run -d \
+      docker run \
         -e PROFILE=console \
         --name=topbeat \
         --pid=host \


### PR DESCRIPTION
Docker doesn't print to the console when it is running in detached mode, which is why this paramter should probably be omitted in this case.
